### PR TITLE
Allowing different ports to be used in nodes

### DIFF
--- a/10/debian-10/docker-compose.yml
+++ b/10/debian-10/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:10
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/10/debian-10/prebuildfs/libnet.sh
+++ b/10/debian-10/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/10/debian-10/prebuildfs/libnet.sh
+++ b/10/debian-10/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/10/debian-10/prebuildfs/libnet.sh
+++ b/10/debian-10/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/10/debian-10/prebuildfs/libnet.sh
+++ b/10/debian-10/prebuildfs/libnet.sh
@@ -95,7 +95,7 @@ parse_uri() {
             index=14
             ;;
         *)
-            stderr_print "unrecognized component $1"
+            stderr_print "unrecognized component $component"
             return 1
             ;;
     esac

--- a/10/debian-10/prebuildfs/libnet.sh
+++ b/10/debian-10/prebuildfs/libnet.sh
@@ -62,7 +62,7 @@ parse_uri() {
     # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
-    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
     #                    ||            |  |||            |         | |            | |        |  |        | |
     #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
     #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...

--- a/10/debian-10/rootfs/librepmgr.sh
+++ b/10/debian-10/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/10/debian-10/rootfs/librepmgr.sh
+++ b/10/debian-10/rootfs/librepmgr.sh
@@ -193,7 +193,7 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_uri "$node" 'hostname')
+            local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."

--- a/10/debian-10/rootfs/librepmgr.sh
+++ b/10/debian-10/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/10/debian-10/rootfs/librepmgr.sh
+++ b/10/debian-10/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/10/debian-10/rootfs/librepmgr.sh
+++ b/10/debian-10/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/10/ol-7/docker-compose.yml
+++ b/10/ol-7/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:10-ol-7
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/10/ol-7/prebuildfs/libnet.sh
+++ b/10/ol-7/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/10/ol-7/prebuildfs/libnet.sh
+++ b/10/ol-7/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/10/ol-7/prebuildfs/libnet.sh
+++ b/10/ol-7/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/10/ol-7/prebuildfs/libnet.sh
+++ b/10/ol-7/prebuildfs/libnet.sh
@@ -2,6 +2,9 @@
 #
 # Library for network functions
 
+# Load Generic Libraries
+. /liblog.sh
+
 # Functions
 
 ########################
@@ -48,27 +51,53 @@ is_hostname_resolved() {
 # Globals:
 #   None
 # Arguments:
-#   $1 - url - String
-#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
+#   $1 - uri - String
+#   $2 - component to obtain. Valid options (scheme, authority, userinfo, host, port, path, query or fragment) - String
 # Returns:
 #   String
-parse_url() {
-	local url=$1
-	local field_to_obtain=$2
+parse_uri() {
+    local uri="${1:?uri is missing}"
+    local component="${2:?component is missing}"
 
-	if [[ "$field_to_obtain" == "protocol" ]]; then
-	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
-	  echo "$extracted_protocol"
-	fi
-	if [[ "$field_to_obtain" == "hostname" ]]; then
-    local extracted_hostname="${url##*'://'}"
-    extracted_hostname="${extracted_hostname%:*}"
-	  echo "$extracted_hostname"
-	fi
-	if [[ "$field_to_obtain" == "port" ]]; then
-	  local extracted_port="${url##*'://'}"
-	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
-	  echo "$extracted_port"
-	fi
-  echo ''
+    # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
+    # additional sub-expressions to split authority into userinfo, host and port
+    # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
+    #                    ||            |  |||            |         | |            | |        |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                                  |  4 authority
+    #                                  3 //...
+    local index=0
+    case "$component" in
+        scheme)
+            index=2
+            ;;
+        authority)
+            index=4
+            ;;
+        userinfo)
+            index=6
+            ;;
+        host)
+            index=7
+            ;;
+        port)
+            index=9
+            ;;
+        path)
+            index=10
+            ;;
+        query)
+            index=13
+            ;;
+        fragment)
+            index=14
+            ;;
+        *)
+            stderr_print "unrecognized component $component"
+            return 1
+            ;;
+    esac
+    [[ "$uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
 }

--- a/10/ol-7/rootfs/librepmgr.sh
+++ b/10/ol-7/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/10/ol-7/rootfs/librepmgr.sh
+++ b/10/ol-7/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/10/ol-7/rootfs/librepmgr.sh
+++ b/10/ol-7/rootfs/librepmgr.sh
@@ -193,8 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_url "$node" 'hostname')
-            local port=$(parse_url "$node" 'port')
+            local host=$(parse_uri "$node" 'host')
+            local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"

--- a/10/ol-7/rootfs/librepmgr.sh
+++ b/10/ol-7/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/10/ol-7/rootfs/librepmgr.sh
+++ b/10/ol-7/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/11/debian-10/docker-compose.yml
+++ b/11/debian-10/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:11
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/11/debian-10/prebuildfs/libnet.sh
+++ b/11/debian-10/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/11/debian-10/prebuildfs/libnet.sh
+++ b/11/debian-10/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/11/debian-10/prebuildfs/libnet.sh
+++ b/11/debian-10/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/11/debian-10/prebuildfs/libnet.sh
+++ b/11/debian-10/prebuildfs/libnet.sh
@@ -95,7 +95,7 @@ parse_uri() {
             index=14
             ;;
         *)
-            stderr_print "unrecognized component $1"
+            stderr_print "unrecognized component $component"
             return 1
             ;;
     esac

--- a/11/debian-10/prebuildfs/libnet.sh
+++ b/11/debian-10/prebuildfs/libnet.sh
@@ -62,7 +62,7 @@ parse_uri() {
     # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
-    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
     #                    ||            |  |||            |         | |            | |        |  |        | |
     #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
     #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...

--- a/11/debian-10/rootfs/librepmgr.sh
+++ b/11/debian-10/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/11/debian-10/rootfs/librepmgr.sh
+++ b/11/debian-10/rootfs/librepmgr.sh
@@ -193,7 +193,7 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_uri "$node" 'hostname')
+            local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."

--- a/11/debian-10/rootfs/librepmgr.sh
+++ b/11/debian-10/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/11/debian-10/rootfs/librepmgr.sh
+++ b/11/debian-10/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/11/debian-10/rootfs/librepmgr.sh
+++ b/11/debian-10/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/11/ol-7/docker-compose.yml
+++ b/11/ol-7/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:11-ol-7
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/11/ol-7/prebuildfs/libnet.sh
+++ b/11/ol-7/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/11/ol-7/prebuildfs/libnet.sh
+++ b/11/ol-7/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/11/ol-7/prebuildfs/libnet.sh
+++ b/11/ol-7/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/11/ol-7/prebuildfs/libnet.sh
+++ b/11/ol-7/prebuildfs/libnet.sh
@@ -2,6 +2,9 @@
 #
 # Library for network functions
 
+# Load Generic Libraries
+. /liblog.sh
+
 # Functions
 
 ########################
@@ -48,27 +51,53 @@ is_hostname_resolved() {
 # Globals:
 #   None
 # Arguments:
-#   $1 - url - String
-#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
+#   $1 - uri - String
+#   $2 - component to obtain. Valid options (scheme, authority, userinfo, host, port, path, query or fragment) - String
 # Returns:
 #   String
-parse_url() {
-	local url=$1
-	local field_to_obtain=$2
+parse_uri() {
+    local uri="${1:?uri is missing}"
+    local component="${2:?component is missing}"
 
-	if [[ "$field_to_obtain" == "protocol" ]]; then
-	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
-	  echo "$extracted_protocol"
-	fi
-	if [[ "$field_to_obtain" == "hostname" ]]; then
-    local extracted_hostname="${url##*'://'}"
-    extracted_hostname="${extracted_hostname%:*}"
-	  echo "$extracted_hostname"
-	fi
-	if [[ "$field_to_obtain" == "port" ]]; then
-	  local extracted_port="${url##*'://'}"
-	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
-	  echo "$extracted_port"
-	fi
-  echo ''
+    # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
+    # additional sub-expressions to split authority into userinfo, host and port
+    # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
+    #                    ||            |  |||            |         | |            | |        |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                                  |  4 authority
+    #                                  3 //...
+    local index=0
+    case "$component" in
+        scheme)
+            index=2
+            ;;
+        authority)
+            index=4
+            ;;
+        userinfo)
+            index=6
+            ;;
+        host)
+            index=7
+            ;;
+        port)
+            index=9
+            ;;
+        path)
+            index=10
+            ;;
+        query)
+            index=13
+            ;;
+        fragment)
+            index=14
+            ;;
+        *)
+            stderr_print "unrecognized component $component"
+            return 1
+            ;;
+    esac
+    [[ "$uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
 }

--- a/11/ol-7/rootfs/librepmgr.sh
+++ b/11/ol-7/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/11/ol-7/rootfs/librepmgr.sh
+++ b/11/ol-7/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/11/ol-7/rootfs/librepmgr.sh
+++ b/11/ol-7/rootfs/librepmgr.sh
@@ -193,8 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_url "$node" 'hostname')
-            local port=$(parse_url "$node" 'port')
+            local host=$(parse_uri "$node" 'host')
+            local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"

--- a/11/ol-7/rootfs/librepmgr.sh
+++ b/11/ol-7/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/11/ol-7/rootfs/librepmgr.sh
+++ b/11/ol-7/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/12/debian-10/docker-compose.yml
+++ b/12/debian-10/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:12
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/12/debian-10/prebuildfs/libnet.sh
+++ b/12/debian-10/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/12/debian-10/prebuildfs/libnet.sh
+++ b/12/debian-10/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/12/debian-10/prebuildfs/libnet.sh
+++ b/12/debian-10/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/12/debian-10/prebuildfs/libnet.sh
+++ b/12/debian-10/prebuildfs/libnet.sh
@@ -95,7 +95,7 @@ parse_uri() {
             index=14
             ;;
         *)
-            stderr_print "unrecognized component $1"
+            stderr_print "unrecognized component $component"
             return 1
             ;;
     esac

--- a/12/debian-10/prebuildfs/libnet.sh
+++ b/12/debian-10/prebuildfs/libnet.sh
@@ -62,7 +62,7 @@ parse_uri() {
     # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
-    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
     #                    ||            |  |||            |         | |            | |        |  |        | |
     #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
     #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...

--- a/12/debian-10/rootfs/librepmgr.sh
+++ b/12/debian-10/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/12/debian-10/rootfs/librepmgr.sh
+++ b/12/debian-10/rootfs/librepmgr.sh
@@ -193,7 +193,7 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_uri "$node" 'hostname')
+            local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."

--- a/12/debian-10/rootfs/librepmgr.sh
+++ b/12/debian-10/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/12/debian-10/rootfs/librepmgr.sh
+++ b/12/debian-10/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/12/debian-10/rootfs/librepmgr.sh
+++ b/12/debian-10/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/12/ol-7/docker-compose.yml
+++ b/12/ol-7/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:12-ol-7
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/12/ol-7/prebuildfs/libnet.sh
+++ b/12/ol-7/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/12/ol-7/prebuildfs/libnet.sh
+++ b/12/ol-7/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/12/ol-7/prebuildfs/libnet.sh
+++ b/12/ol-7/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/12/ol-7/prebuildfs/libnet.sh
+++ b/12/ol-7/prebuildfs/libnet.sh
@@ -2,6 +2,9 @@
 #
 # Library for network functions
 
+# Load Generic Libraries
+. /liblog.sh
+
 # Functions
 
 ########################
@@ -48,27 +51,53 @@ is_hostname_resolved() {
 # Globals:
 #   None
 # Arguments:
-#   $1 - url - String
-#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
+#   $1 - uri - String
+#   $2 - component to obtain. Valid options (scheme, authority, userinfo, host, port, path, query or fragment) - String
 # Returns:
 #   String
-parse_url() {
-	local url=$1
-	local field_to_obtain=$2
+parse_uri() {
+    local uri="${1:?uri is missing}"
+    local component="${2:?component is missing}"
 
-	if [[ "$field_to_obtain" == "protocol" ]]; then
-	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
-	  echo "$extracted_protocol"
-	fi
-	if [[ "$field_to_obtain" == "hostname" ]]; then
-    local extracted_hostname="${url##*'://'}"
-    extracted_hostname="${extracted_hostname%:*}"
-	  echo "$extracted_hostname"
-	fi
-	if [[ "$field_to_obtain" == "port" ]]; then
-	  local extracted_port="${url##*'://'}"
-	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
-	  echo "$extracted_port"
-	fi
-  echo ''
+    # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
+    # additional sub-expressions to split authority into userinfo, host and port
+    # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
+    #                    ||            |  |||            |         | |            | |        |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                                  |  4 authority
+    #                                  3 //...
+    local index=0
+    case "$component" in
+        scheme)
+            index=2
+            ;;
+        authority)
+            index=4
+            ;;
+        userinfo)
+            index=6
+            ;;
+        host)
+            index=7
+            ;;
+        port)
+            index=9
+            ;;
+        path)
+            index=10
+            ;;
+        query)
+            index=13
+            ;;
+        fragment)
+            index=14
+            ;;
+        *)
+            stderr_print "unrecognized component $component"
+            return 1
+            ;;
+    esac
+    [[ "$uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
 }

--- a/12/ol-7/rootfs/librepmgr.sh
+++ b/12/ol-7/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/12/ol-7/rootfs/librepmgr.sh
+++ b/12/ol-7/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/12/ol-7/rootfs/librepmgr.sh
+++ b/12/ol-7/rootfs/librepmgr.sh
@@ -193,8 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_url "$node" 'hostname')
-            local port=$(parse_url "$node" 'port')
+            local host=$(parse_uri "$node" 'host')
+            local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"

--- a/12/ol-7/rootfs/librepmgr.sh
+++ b/12/ol-7/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/12/ol-7/rootfs/librepmgr.sh
+++ b/12/ol-7/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/9.6/debian-10/docker-compose.yml
+++ b/9.6/debian-10/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:9.6
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/9.6/debian-10/prebuildfs/libnet.sh
+++ b/9.6/debian-10/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/9.6/debian-10/prebuildfs/libnet.sh
+++ b/9.6/debian-10/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/9.6/debian-10/prebuildfs/libnet.sh
+++ b/9.6/debian-10/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/9.6/debian-10/prebuildfs/libnet.sh
+++ b/9.6/debian-10/prebuildfs/libnet.sh
@@ -95,7 +95,7 @@ parse_uri() {
             index=14
             ;;
         *)
-            stderr_print "unrecognized component $1"
+            stderr_print "unrecognized component $component"
             return 1
             ;;
     esac

--- a/9.6/debian-10/prebuildfs/libnet.sh
+++ b/9.6/debian-10/prebuildfs/libnet.sh
@@ -62,7 +62,7 @@ parse_uri() {
     # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
-    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
     #                    ||            |  |||            |         | |            | |        |  |        | |
     #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
     #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...

--- a/9.6/debian-10/rootfs/librepmgr.sh
+++ b/9.6/debian-10/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/9.6/debian-10/rootfs/librepmgr.sh
+++ b/9.6/debian-10/rootfs/librepmgr.sh
@@ -193,7 +193,7 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_uri "$node" 'hostname')
+            local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."

--- a/9.6/debian-10/rootfs/librepmgr.sh
+++ b/9.6/debian-10/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/9.6/debian-10/rootfs/librepmgr.sh
+++ b/9.6/debian-10/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/9.6/debian-10/rootfs/librepmgr.sh
+++ b/9.6/debian-10/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/9.6/ol-7/docker-compose.yml
+++ b/9.6/ol-7/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:9.6-ol-7
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local

--- a/9.6/ol-7/prebuildfs/libnet.sh
+++ b/9.6/ol-7/prebuildfs/libnet.sh
@@ -42,3 +42,48 @@ is_hostname_resolved() {
         false
     fi
 }
+
+########################
+# Check that node_address can be IPv6 format
+# Arguments:
+#   $1 - node_address - String
+# Returns:
+#   Boolean
+#########################
+canBeIPv6() {
+	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
+}
+
+########################
+# Extract host and port from address
+# Globals:
+#   None
+# Arguments:
+#   $1 - node_address - String
+#   $2 - default_port - Integer
+# Returns:
+#   Array - (host port)
+#########################
+extractHostAndPort() {
+	local node_address=$1
+	local default_port=$2
+	local extracted_host=$node_address;
+	local extracted_port=$default_port;
+
+	if canBeIPv6 $node_address; then
+		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
+			extracted_host="${node_address%']'*}"
+			extracted_host="${extracted_host##*'['}"
+
+			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
+			extracted_port=${extracted_port:-default_port}
+		fi
+	else
+		extracted_host="${node_address%:*}"
+
+		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
+		extracted_port=${extracted_port:-default_port}
+	fi
+	echo $extracted_host
+	echo $extracted_port
+}

--- a/9.6/ol-7/prebuildfs/libnet.sh
+++ b/9.6/ol-7/prebuildfs/libnet.sh
@@ -63,9 +63,9 @@ parse_uri() {
     # additional sub-expressions to split authority into userinfo, host and port
     # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
     local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
-    #                    ||            |  |||            |         | |            | |        |  |        | |
-    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
-    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
     #                                  |  4 authority
     #                                  3 //...
     local index=0

--- a/9.6/ol-7/prebuildfs/libnet.sh
+++ b/9.6/ol-7/prebuildfs/libnet.sh
@@ -44,46 +44,31 @@ is_hostname_resolved() {
 }
 
 ########################
-# Check that node_address can be IPv6 format
-# Arguments:
-#   $1 - node_address - String
-# Returns:
-#   Boolean
-#########################
-canBeIPv6() {
-	[[ $(echo $1  | grep -o ':' | wc -l) -ge 2 ]]
-}
-
-########################
-# Extract host and port from address
+# Parse URL
 # Globals:
 #   None
 # Arguments:
-#   $1 - node_address - String
-#   $2 - default_port - Integer
+#   $1 - url - String
+#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
 # Returns:
-#   Array - (host port)
-#########################
-extractHostAndPort() {
-	local node_address=$1
-	local default_port=$2
-	local extracted_host=$node_address;
-	local extracted_port=$default_port;
+#   String
+parse_url() {
+	local url=$1
+	local field_to_obtain=$2
 
-	if canBeIPv6 $node_address; then
-		if [[ $node_address =~ ^\[[^\]]+\]:[0-9]+$ ]]; then
-			extracted_host="${node_address%']'*}"
-			extracted_host="${extracted_host##*'['}"
-
-			extracted_port=$([[ "$node_address" = *']:'* ]] && echo "${node_address##*']:'}" || echo "$default_port")
-			extracted_port=${extracted_port:-default_port}
-		fi
-	else
-		extracted_host="${node_address%:*}"
-
-		extracted_port=$([[ "$node_address" = *':'* ]] && echo "${node_address##*':'}" || echo "$default_port")
-		extracted_port=${extracted_port:-default_port}
+	if [[ "$field_to_obtain" == "protocol" ]]; then
+	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
+	  echo "$extracted_protocol"
 	fi
-	echo $extracted_host
-	echo $extracted_port
+	if [[ "$field_to_obtain" == "hostname" ]]; then
+    local extracted_hostname="${url##*'://'}"
+    extracted_hostname="${extracted_hostname%:*}"
+	  echo "$extracted_hostname"
+	fi
+	if [[ "$field_to_obtain" == "port" ]]; then
+	  local extracted_port="${url##*'://'}"
+	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
+	  echo "$extracted_port"
+	fi
+  echo ''
 }

--- a/9.6/ol-7/prebuildfs/libnet.sh
+++ b/9.6/ol-7/prebuildfs/libnet.sh
@@ -2,6 +2,9 @@
 #
 # Library for network functions
 
+# Load Generic Libraries
+. /liblog.sh
+
 # Functions
 
 ########################
@@ -48,27 +51,53 @@ is_hostname_resolved() {
 # Globals:
 #   None
 # Arguments:
-#   $1 - url - String
-#   $2 - field to obtain. Valid options (protocol, hostname, or port) - String
+#   $1 - uri - String
+#   $2 - component to obtain. Valid options (scheme, authority, userinfo, host, port, path, query or fragment) - String
 # Returns:
 #   String
-parse_url() {
-	local url=$1
-	local field_to_obtain=$2
+parse_uri() {
+    local uri="${1:?uri is missing}"
+    local component="${2:?component is missing}"
 
-	if [[ "$field_to_obtain" == "protocol" ]]; then
-	  local extracted_protocol=$([[ "$url" = *'://'* ]] && echo "${url%://*}" || echo '')
-	  echo "$extracted_protocol"
-	fi
-	if [[ "$field_to_obtain" == "hostname" ]]; then
-    local extracted_hostname="${url##*'://'}"
-    extracted_hostname="${extracted_hostname%:*}"
-	  echo "$extracted_hostname"
-	fi
-	if [[ "$field_to_obtain" == "port" ]]; then
-	  local extracted_port="${url##*'://'}"
-	  extracted_port=$([[ "$extracted_port" = *':'* ]] && echo "${extracted_port##*':'}" || echo "$default_port")
-	  echo "$extracted_port"
-	fi
-  echo ''
+    # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
+    # additional sub-expressions to split authority into userinfo, host and port
+    # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
+    #                    ||            |  |||            |         | |            | |        |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path    12 ?...     14 #...
+    #                                  |  4 authority
+    #                                  3 //...
+    local index=0
+    case "$component" in
+        scheme)
+            index=2
+            ;;
+        authority)
+            index=4
+            ;;
+        userinfo)
+            index=6
+            ;;
+        host)
+            index=7
+            ;;
+        port)
+            index=9
+            ;;
+        path)
+            index=10
+            ;;
+        query)
+            index=13
+            ;;
+        fragment)
+            index=14
+            ;;
+        *)
+            stderr_print "unrecognized component $component"
+            return 1
+            ;;
+    esac
+    [[ "$uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
 }

--- a/9.6/ol-7/rootfs/librepmgr.sh
+++ b/9.6/ol-7/rootfs/librepmgr.sh
@@ -193,10 +193,9 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local address=()
-            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
-            local host=${address[0]}
-            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            local host=$(parse_url "$node" 'hostname')
+            local port=$(parse_url "$node" 'port')
+            port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then

--- a/9.6/ol-7/rootfs/librepmgr.sh
+++ b/9.6/ol-7/rootfs/librepmgr.sh
@@ -198,10 +198,10 @@ repmgr_get_upstream_node() {
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
-            repmgr_debug "Checking node $host,$port..."
+            repmgr_debug "Checking node $host:$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
             if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
+                repmgr_debug "Skipping: failed to get primary from the node $host:$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
@@ -221,7 +221,7 @@ repmgr_get_upstream_node() {
                     pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                repmgr_warn "There were more than one primary when getting primary from node $host:$port"
                 pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
@@ -511,11 +511,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
         if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -640,7 +640,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/9.6/ol-7/rootfs/librepmgr.sh
+++ b/9.6/ol-7/rootfs/librepmgr.sh
@@ -193,8 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            local host=$(parse_url "$node" 'hostname')
-            local port=$(parse_url "$node" 'port')
+            local host=$(parse_uri "$node" 'host')
+            local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}
             repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"

--- a/9.6/ol-7/rootfs/librepmgr.sh
+++ b/9.6/ol-7/rootfs/librepmgr.sh
@@ -193,6 +193,8 @@ repmgr_get_upstream_node() {
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
+            # intentionally accept inncorect address (without [schema:]// )
+            [[ "$node" =~ ^(([^:/?#]+):)?// ]] || node="tcp://${node}"
             local host=$(parse_uri "$node" 'host')
             local port=$(parse_uri "$node" 'port')
             port=${port:-$REPMGR_PRIMARY_PORT}

--- a/9.6/ol-7/rootfs/librepmgr.sh
+++ b/9.6/ol-7/rootfs/librepmgr.sh
@@ -11,6 +11,7 @@
 . /liblog.sh
 . /libos.sh
 . /libvalidations.sh
+. /libnet.sh
 
 ########################
 # Overwrite info, debug, warn and error functions (liblog.sh)
@@ -80,6 +81,7 @@ export REPMGR_UPGRADE_EXTENSION="${REPMGR_UPGRADE_EXTENSION:-no}"
 # These are internal
 export REPMGR_SWITCH_ROLE="${REPMGR_SWITCH_ROLE:-no}"
 export REPMGR_CURRENT_PRIMARY_HOST=""
+export REPMGR_CURRENT_PRIMARY_PORT="${REPMGR_PRIMARY_PORT}"
 
 # Aliases to setup PostgreSQL environment variables
 export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
@@ -180,44 +182,52 @@ repmgr_validate() {
 # Arguments:
 #   Non
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_upstream_node() {
     local primary_conninfo
-    local pretending_primary=""
+    local pretending_primary_host=""
+    local pretending_primary_port=""
 
     if [[ -n "$REPMGR_PARTNER_NODES" ]]; then
         repmgr_info "Querying all partner nodes for common upstream node..."
         read -r -a nodes <<< "$(tr ',;' ' ' <<< "${REPMGR_PARTNER_NODES}")"
         for node in "${nodes[@]}"; do
-            repmgr_debug "Checking node $node..."
+            local address=()
+            readarray -t address < <(extractHostAndPort $node $REPMGR_PRIMARY_PORT)
+            local host=${address[0]}
+            local port=${address[1]:-$REPMGR_PRIMARY_PORT}
+            repmgr_debug "Checking node $host,$port..."
             local query="SELECT conninfo FROM repmgr.show_nodes WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"
-            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$node" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-                repmgr_debug "Skipping: failed to get primary from the node $node!"
+            if ! primary_conninfo="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$host" "$port" "-tA")"; then
+                repmgr_debug "Skipping: failed to get primary from the node $host,$port!"
                 continue
             elif [[ -z "$primary_conninfo" ]]; then
                 repmgr_debug "Skipping: failed to get information about primary nodes!"
                 continue
             elif [[ "$(echo "$primary_conninfo" | wc -l)" -eq 1 ]]; then
-                local -r suggested_primary="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
-                repmgr_debug "Pretending primary role node - ${suggested_primary}"
-                if [[ -n "$pretending_primary" ]]; then
-                    if [[ "${pretending_primary}" != "${suggested_primary}" ]]; then
-                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary, now: $suggested_primary)"
-                        pretending_primary="" && break
+                local -r suggested_primary_host="$(echo "$primary_conninfo" | awk -F 'host=' '{print $2}' | awk '{print $1}')"
+                local -r suggested_primary_port="$(echo "$primary_conninfo" | awk -F 'port=' '{print $2}' | awk '{print $1}')"
+                repmgr_debug "Pretending primary role node - ${suggested_primary_host},${suggested_primary_port}"
+                if [[ -n "$pretending_primary_host" ]]; then
+                    if [[ "${pretending_primary_host},${pretending_primary_port}" != "${suggested_primary_host},${suggested_primary_port}" ]]; then
+                        repmgr_warn "Conflict of pretending primary role nodes (previously: $pretending_primary_host,$pretending_primary_port, now: $suggested_primary_host,$suggested_primary_port)"
+                        pretending_primary_host="" && pretending_primary_port="" && break
                     fi
                 else
-                    repmgr_debug "Pretending primary set to $suggested_primary!"
-                    pretending_primary="$suggested_primary"
+                    repmgr_debug "Pretending primary set to $suggested_primary_host,$suggested_primary_port!"
+                    pretending_primary_host="$suggested_primary_host"
+                    pretending_primary_port="$suggested_primary_port"
                 fi
             else
-                repmgr_warn "There were more than one primary when getting primary from node $node"
-                pretending_primary="" && break
+                repmgr_warn "There were more than one primary when getting primary from node $host,$port"
+                pretending_primary_host="" && pretending_primary_port="" && break
             fi
         done
     fi
 
-    echo "$pretending_primary"
+    echo "$pretending_primary_host"
+    echo "$pretending_primary_port"
 }
 
 ########################
@@ -227,36 +237,49 @@ repmgr_get_upstream_node() {
 # Arguments:
 #   None
 # Returns:
-#   String
+#   String[] - (host port)
 #########################
 repmgr_get_primary_node() {
     local upstream_node
-    local primary_node=""
+    local upstream_host
+    local upstream_port
+    local primary_host=""
+    local primary_port="$REPMGR_PRIMARY_PORT"
 
-    upstream_node="$(repmgr_get_upstream_node)"
-    [[ -n "$upstream_node" ]] && repmgr_info "Auto-detected primary node: '$upstream_node'"
+    readarray -t upstream_node < <(repmgr_get_upstream_node)
+    upstream_host=${upstream_node[0]}
+    upstream_port=${upstream_node[1]:-$REPMGR_PRIMARY_PORT}
+
+
+    [[ -n "$upstream_host" ]] && repmgr_info "Auto-detected primary node: '$upstream_host,$upstream_port'"
 
     if [[ -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME" ]]; then
         repmgr_info "This node was acting as a primary before restart!"
 
-        if [[ -z "$upstream_node" ]] || [[ "$upstream_node" = "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        if [[ -z "$upstream_host" ]] || [[ "$upstream_host,$upstream_port" = "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
             repmgr_info "Can not find new primary. Starting PostgreSQL normally..."
         else
-            repmgr_info "Current master is $upstream_node. Cloning/rewinding it and acting as a standby node..."
+            repmgr_info "Current master is $upstream_host,$upstream_port. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
             export REPMGR_SWITCH_ROLE="yes"
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     else
-        if [[ -z "$upstream_node" ]]; then
-            [[ "$REPMGR_PRIMARY_HOST" != "$REPMGR_NODE_NETWORK_NAME" ]] && primary_node="$REPMGR_PRIMARY_HOST"
+        if [[ -z "$upstream_host" ]]; then
+            if [[ "$REPMGR_PRIMARY_HOST,$REPMGR_PRIMARY_PORT" != "$REPMGR_NODE_NETWORK_NAME,$REPMGR_PORT_NUMBER" ]]; then
+              primary_host="$REPMGR_PRIMARY_HOST"
+              primary_port="$REPMGR_PRIMARY_PORT"
+            fi
         else
-            primary_node="$upstream_node"
+            primary_host="$upstream_host"
+            primary_port="$upstream_port"
         fi
     fi
 
-    [[ -n "$primary_node" ]] && repmgr_debug "Primary node: $primary_node"
-    echo "$primary_node"
+    [[ -n "$primary_host" ]] && repmgr_debug "Primary node: $primary_host,$primary_port"
+    echo "$primary_host"
+    echo "$primary_port"
 }
 
 ########################
@@ -271,16 +294,22 @@ repmgr_get_primary_node() {
 repmgr_set_role() {
     local role="standby"
     local primary_node
+    local primary_host
+    local primary_port
 
-    primary_node="$(repmgr_get_primary_node)"
-    if [[ -z "$primary_node" ]]; then
+    readarray -t primary_node < <(repmgr_get_primary_node)
+    primary_host=${primary_node[0]}
+    primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+
+    if [[ -z "$primary_host" ]]; then
         repmgr_info "There are no nodes with primary role. Assuming the primary role..."
         role="primary"
     fi
 
     cat <<EOF
 export REPMGR_ROLE="$role"
-export REPMGR_CURRENT_PRIMARY_HOST="$primary_node"
+export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
+export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
 EOF
 }
 
@@ -450,7 +479,7 @@ pg_bindir='${POSTGRESQL_BIN_DIR}'
 # FIXME: these 2 parameter should work
 node_id=$(repmgr_get_node_id)
 node_name='${REPMGR_NODE_NAME}'
-conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PRIMARY_PORT} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
+conninfo='user=${REPMGR_USERNAME} password=${REPMGR_PASSWORD} host=${REPMGR_NODE_NETWORK_NAME} dbname=${REPMGR_DATABASE} port=${REPMGR_PORT_NUMBER} connect_timeout=${REPMGR_CONNECT_TIMEOUT}'
 failover='automatic'
 promote_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby promote -f "${REPMGR_CONF_FILE}" --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=${REPMGR_PASSWORD} repmgr standby follow -f "${REPMGR_CONF_FILE}" -W --log-level DEBUG --verbose'
@@ -481,11 +510,11 @@ repmgr_wait_primary_node() {
     local -i max_tries=$(( timeout / step ))
     local schemata
     repmgr_info "Waiting for primary node..."
-    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
+    repmgr_debug "Wait for schema $REPMGR_DATABASE.repmgr on $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT, will try $max_tries times with $step delay seconds (TIMEOUT=$timeout)"
     for ((i = 0 ; i <= timeout ; i+=step )); do
         local query="SELECT 1 FROM information_schema.schemata WHERE catalog_name='$REPMGR_DATABASE' AND schema_name='repmgr'"
-        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_PRIMARY_PORT" "-tA")"; then
-            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST:$REPMGR_PRIMARY_PORT is not accessible"
+        if ! schemata="$(echo "$query" | NO_ERRORS=true postgresql_execute "$REPMGR_DATABASE" "$REPMGR_USERNAME" "$REPMGR_PASSWORD" "$REPMGR_CURRENT_PRIMARY_HOST" "$REPMGR_CURRENT_PRIMARY_PORT" "-tA")"; then
+            repmgr_debug "Host $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT is not accessible"
         else
             if [[ $schemata -ne 1 ]]; then
                 repmgr_debug "Schema $REPMGR_DATABASE.repmgr is still not accessible"
@@ -511,7 +540,7 @@ repmgr_wait_primary_node() {
 #########################
 repmgr_clone_primary() {
     repmgr_info "Cloning data from primary node..."
-    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
+    local -r flags=("-f" "$REPMGR_CONF_FILE" "-h" "$REPMGR_CURRENT_PRIMARY_HOST" "-p" "$REPMGR_CURRENT_PRIMARY_PORT" "-U" "$REPMGR_USERNAME" "-d" "$REPMGR_DATABASE" "-D" "$POSTGRESQL_DATA_DIR" "standby" "clone" "--fast-checkpoint" "--force")
 
     PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${REPMGR_BIN_DIR}/repmgr" "${flags[@]}"
 }
@@ -610,7 +639,7 @@ repmgr_upgrade_extension() {
 #   None
 #########################
 repmgr_initialize() {
-    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST"
+    repmgr_debug "Node ID: $(repmgr_get_node_id), Rol: $REPMGR_ROLE, Primary Node: $REPMGR_CURRENT_PRIMARY_HOST,$REPMGR_CURRENT_PRIMARY_PORT"
     repmgr_info "Initializing Repmgr..."
 
     if [[ "$REPMGR_ROLE" = "standby" ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
+      - REPMGR_PORT_NUMBER=5432
   pg-1:
     image: bitnami/postgresql-repmgr:11
     ports:
@@ -29,9 +31,11 @@ services:
       - POSTGRESQL_DATABASE=customdatabase
       - REPMGR_PASSWORD=repmgrpassword
       - REPMGR_PRIMARY_HOST=pg-0
-      - REPMGR_PARTNER_NODES=pg-0,pg-1
+      - REPMGR_PRIMARY_PORT=5432
+      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
+      - REPMGR_PORT_NUMBER=5432
 volumes:
   pg_0_data:
     driver: local


### PR DESCRIPTION
It could be useful, if we can use a different port for each node.
So, I modified scripts for this and now you can specify own port using enviroment `REPMGR_PORT_NUMBER` and adding port to `REPMGR_PARTNER_NODES`

E.g.
```
# Node 1
      - REPMGR_PRIMARY_HOST=172.17.0.1
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=172.17.0.1:5432,172.17.0.1:5433
      - REPMGR_NODE_NAME=pg-0
      - REPMGR_NODE_NETWORK_NAME=172.17.0.1
      - REPMGR_PORT_NUMBER=5432
# Node 2
      - REPMGR_PRIMARY_HOST=172.17.0.1
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=172.17.0.1:5432,172.17.0.1:5433
      - REPMGR_NODE_NAME=pg-1
      - REPMGR_NODE_NETWORK_NAME=172.17.0.1
      - REPMGR_PORT_NUMBER=5433
```

Feel free to comment/modify that PR to fulfill your vision.


I tested this using docker-compose.yml:
(You have to change IP 172.17.0.1 to yours ip (or leave that, because it is docker ip on linux host machine, so it could be the same like yours))

```
version: '2'
services:
  pg-0:
    image: bitnami/postgresql-repmgr:12
    ports:
      - 5432:5432
    volumes:
      - pg_0_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=172.17.0.1
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=172.17.0.1:5432,172.17.0.1:5433
      - REPMGR_NODE_NAME=pg-0
      - REPMGR_NODE_NETWORK_NAME=172.17.0.1
      - REPMGR_PORT_NUMBER=5432
      - REPMGR_LOG_LEVEL=DEBUG
  pg-1:
    image: bitnami/postgresql-repmgr:12
    ports:
      - 5433:5432
    volumes:
      - pg_1_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=172.17.0.1
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=172.17.0.1:5432,172.17.0.1:5433
      - REPMGR_NODE_NAME=pg-1
      - REPMGR_NODE_NETWORK_NAME=172.17.0.1
      - REPMGR_PORT_NUMBER=5433
      - REPMGR_LOG_LEVEL=DEBUG
volumes:
  pg_0_data:
    driver: local
  pg_1_data:
    driver: local

```


After run the compose file, execute command(s) ;) :
```
echo 'Creating user which is needed by repmgr command.'; \
docker exec -u root -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'useradd -b /opt -m -s /bin/bash repmgr -u 1001 && chown -R repmgr:100 /opt/bitnami/*/tmp' && \
docker exec -u root -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'useradd -b /opt -m -s /bin/bash repmgr -u 1001 && chown -R repmgr:100 /opt/bitnami/*/tmp' && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Stopping server 0.'; \
docker stop bitnami-docker-postgresql-repmgr_pg-0_1 && \
\
sleep 15s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Starting server 0.'; \
docker start bitnami-docker-postgresql-repmgr_pg-0_1 && \
\
sleep 15s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Stopping server 1.'; \
docker stop bitnami-docker-postgresql-repmgr_pg-1_1 && \
\
sleep 15s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Starting server 1.'; \
docker start bitnami-docker-postgresql-repmgr_pg-1_1 && \
\
sleep 15s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'

```