### PR TITLE
Set wait counter for stopping service to 60s and fail if not terminated

### DIFF
--- a/10/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
+++ b/10/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
@@ -62,11 +62,16 @@ stop_service_using_pid() {
         kill "$pid"
     fi
 
-    local counter=10
+    local counter=60
     while [[ "$counter" -ne 0 ]] && is_service_running "$pid"; do
         sleep 1
         counter=$((counter - 1))
     done
+
+    if [[ "$counter" -eq 0 ]] && is_service_running "$pid"; then
+      echo "The process with pid $pid has not terminated in 60 seconds."
+      return 1
+    fi
 }
 
 ########################

--- a/11/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
+++ b/11/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
@@ -62,11 +62,16 @@ stop_service_using_pid() {
         kill "$pid"
     fi
 
-    local counter=10
+    local counter=60
     while [[ "$counter" -ne 0 ]] && is_service_running "$pid"; do
         sleep 1
         counter=$((counter - 1))
     done
+
+    if [[ "$counter" -eq 0 ]] && is_service_running "$pid"; then
+      echo "The process with pid $pid has not terminated in 60 seconds."
+      return 1
+    fi
 }
 
 ########################

--- a/12/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
+++ b/12/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
@@ -62,11 +62,16 @@ stop_service_using_pid() {
         kill "$pid"
     fi
 
-    local counter=10
+    local counter=60
     while [[ "$counter" -ne 0 ]] && is_service_running "$pid"; do
         sleep 1
         counter=$((counter - 1))
     done
+
+    if [[ "$counter" -eq 0 ]] && is_service_running "$pid"; then
+      echo "The process with pid $pid has not terminated in 60 seconds."
+      return 1
+    fi
 }
 
 ########################

--- a/13/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
+++ b/13/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
@@ -62,11 +62,16 @@ stop_service_using_pid() {
         kill "$pid"
     fi
 
-    local counter=10
+    local counter=60
     while [[ "$counter" -ne 0 ]] && is_service_running "$pid"; do
         sleep 1
         counter=$((counter - 1))
     done
+
+    if [[ "$counter" -eq 0 ]] && is_service_running "$pid"; then
+      echo "The process with pid $pid has not terminated in 60 seconds."
+      return 1
+    fi
 }
 
 ########################

--- a/9.6/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
+++ b/9.6/debian-10/prebuildfs/opt/bitnami/scripts/libservice.sh
@@ -62,11 +62,16 @@ stop_service_using_pid() {
         kill "$pid"
     fi
 
-    local counter=10
+    local counter=60
     while [[ "$counter" -ne 0 ]] && is_service_running "$pid"; do
         sleep 1
         counter=$((counter - 1))
     done
+
+    if [[ "$counter" -eq 0 ]] && is_service_running "$pid"; then
+      echo "The process with pid $pid has not terminated in 60 seconds."
+      return 1
+    fi
 }
 
 ########################


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

A detailed explanation of the underlaying problem can be found at In https://github.com/bitnami/charts/issues/1880#issuecomment-698589171.

**Description of the change**
The wait counter for stopping services is set from 10s to 60s and an error is returned, if the process has not terminated.

**Benefits**
When using persistent storage in Kubernetes, access of files can be slowed down. The termination process of postgres during the initialization can take more than 10s. With this change, the container starts successfully even with a slower file system.

**Applicable issues**

Fixes https://github.com/bitnami/charts/issues/1880

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
