### PR TITLE
Run a Postgres cluster that listens on a custom port 

### DIFF
--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres")
+    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
         sleep 1

--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -797,8 +797,9 @@ postgresql_start_bg() {
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
     local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
-    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
+    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do
         sleep 1
         counter=$((counter - 1))
         if ((counter <= 0)); then

--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args=("-U" "postgres")
     local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres")
+    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
         sleep 1

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -797,8 +797,9 @@ postgresql_start_bg() {
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
     local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
-    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
+    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do
         sleep 1
         counter=$((counter - 1))
         if ((counter <= 0)); then

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args=("-U" "postgres")
     local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres")
+    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
         sleep 1

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -797,8 +797,9 @@ postgresql_start_bg() {
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
     local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
-    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
+    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do
         sleep 1
         counter=$((counter - 1))
         if ((counter <= 0)); then

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args=("-U" "postgres")
     local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do

--- a/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres")
+    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
         sleep 1

--- a/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -797,8 +797,9 @@ postgresql_start_bg() {
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
     local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
-    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
+    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do
         sleep 1
         counter=$((counter - 1))
         if ((counter <= 0)); then

--- a/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args=("-U" "postgres")
     local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do

--- a/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,7 +796,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres")
+    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
         sleep 1

--- a/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -796,9 +796,10 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local -r pg_isready_args=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
+    local -r pg_isready_args=("-U" "postgres")
+    local -r pg_isready_args_custom_port=("-U" "postgres" "-p" "${POSTGRESQL_PORT_NUMBER}")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
-    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
+    while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1 && ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args_custom_port[@]}" >/dev/null 2>&1; do
         sleep 1
         counter=$((counter - 1))
         if ((counter <= 0)); then


### PR DESCRIPTION
**Description of the change**

At database cluster initialisation time, the process checks the connectivity to Postgres using the default port, 5432.
Then, once the cluster setup is about to complete, it checks the connectivity to Postgres a second time, but, if a custom port has been set up, that check will fail because the service behind is listening on that port and not on the default one, this time.
