### PR TITLE
feat: ensure clean shutdown of postgres before pg_rewind is executed

### DIFF
--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -558,6 +558,22 @@ postgresql_clean_from_restart() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Ensure PostgreSQL is initialized
 # Globals:
 #   POSTGRESQL_*
@@ -573,11 +589,8 @@ postgresql_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$POSTGRESQL_PID_FILE"
 
-    # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/10/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -623,6 +623,18 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
     local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -558,6 +558,22 @@ postgresql_clean_from_restart() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Ensure PostgreSQL is initialized
 # Globals:
 #   POSTGRESQL_*
@@ -573,11 +589,8 @@ postgresql_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$POSTGRESQL_PID_FILE"
 
-    # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/11/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -623,6 +623,18 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
     local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -558,6 +558,22 @@ postgresql_clean_from_restart() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Ensure PostgreSQL is initialized
 # Globals:
 #   POSTGRESQL_*
@@ -573,11 +589,8 @@ postgresql_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$POSTGRESQL_PID_FILE"
 
-    # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/12/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -623,6 +623,18 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
     local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then

--- a/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -558,6 +558,22 @@ postgresql_clean_from_restart() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Ensure PostgreSQL is initialized
 # Globals:
 #   POSTGRESQL_*
@@ -573,11 +589,8 @@ postgresql_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$POSTGRESQL_PID_FILE"
 
-    # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/13/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -623,7 +623,19 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
+    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--no-ensure-shutdown"  "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/14/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -558,6 +558,23 @@ postgresql_clean_from_restart() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+
+########################
 # Ensure PostgreSQL is initialized
 # Globals:
 #   POSTGRESQL_*
@@ -573,11 +590,8 @@ postgresql_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$POSTGRESQL_PID_FILE"
 
-    # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/14/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -623,7 +623,19 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
+    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--no-ensure-shutdown" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This is a proof of concept to ensure a clean shutdown of postgres before pg_rewind is called. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

In order to execute pg_rewind postgres it has to be stopped correctly

https://github.com/postgres/postgres/blob/ffd53659c46a54a6978bcb8c4424c1e157a2c0f1/src/bin/pg_rewind/pg_rewind.c#L298-L307

In pg_rewind there is an method [ensureCleanShutdown](https://github.com/postgres/postgres/blob/ffd53659c46a54a6978bcb8c4424c1e157a2c0f1/src/bin/pg_rewind/pg_rewind.c#L1089) that takes care of this. I cannot get this method to function properly due to changes in the configuration. 

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

The postgres server is started as regular but I think there are some flags to be added (or by pass pg_ctl like pg_rewind is doing) to gain some speed. 

<!-- Describe any known limitations with your change -->


**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

#82 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

This pull-request is limited to postgres version 12 and 13 because I would like to discuss my approach before duplicating it to the other images. 
